### PR TITLE
Apply text-right class for right-aligned text

### DIFF
--- a/src/layouts/partials/Header.tsx
+++ b/src/layouts/partials/Header.tsx
@@ -56,7 +56,7 @@ const Header = () => {
                   </span>
                   <ul className="nav-dropdown-list hidden group-hover:block lg:invisible lg:absolute lg:block lg:opacity-0 lg:group-hover:visible lg:group-hover:opacity-100">
                     {menu.children?.map((child, i) => (
-                      <li className="nav-dropdown-item" key={`children-${i}`}>
+                      <li className="nav-dropdown-item text-right" key={`children-${i}`}>
                         <Link
                           href={child.url}
                           className={`nav-dropdown-link block`}


### PR DESCRIPTION
I applied the `text-right` class to relevant HTML elements to right-align text content.

Before the change

![צילום מסך 2023-08-29 114019](https://github.com/noams24/Kef-Code/assets/114335827/3b1e4339-2e37-4c42-897a-8dbb82aafb6b)

After the change

![image](https://github.com/noams24/Kef-Code/assets/114335827/2cdb9c33-9425-4216-b925-a73793b3a594)
